### PR TITLE
fix: lowered required terraform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Terraform module which creates sqs queue(s)
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30.0 |
 
 ## Providers

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.0.0"
 }

--- a/examples/filled-via-sns/versions.tf
+++ b/examples/filled-via-sns/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.0.0"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -5,5 +5,5 @@ terraform {
       version = ">= 4.30.0"
     }
   }
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.0.0"
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
